### PR TITLE
Add role-based access control to landlord layout

### DIFF
--- a/app/landlord/layout.tsx
+++ b/app/landlord/layout.tsx
@@ -1,4 +1,22 @@
+"use client";
+
+import { RoleGuard } from "@/components/auth/role-guard";
 import LandlordHeader from "@/components/landlord-header";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+// Redirect component for unauthorized users
+function RedirectToListings() {
+	const router = useRouter();
+
+	useEffect(() => {
+		// Redirect to listings page
+		router.push("/listings");
+	}, [router]);
+
+	// Return null (no UI) while redirecting
+	return null;
+}
 
 export default function LandlordLayout({
 	children,
@@ -6,9 +24,14 @@ export default function LandlordLayout({
 	children: React.ReactNode;
 }) {
 	return (
-		<div className="min-h-screen flex flex-col">
-			<LandlordHeader />
-			<div className="container mx-auto py-6 flex-1">{children}</div>
-		</div>
+		<RoleGuard
+			requiredPermission="canCreateListings"
+			fallback={<RedirectToListings />}
+		>
+			<div className="min-h-screen flex flex-col">
+				<LandlordHeader />
+				<div className="container mx-auto py-6 flex-1">{children}</div>
+			</div>
+		</RoleGuard>
 	);
 }


### PR DESCRIPTION
### TL;DR

Added role-based access control to the landlord section of the application.

### What changed?

- Made the landlord layout a client component by adding the "use client" directive
- Implemented a `RedirectToListings` component that redirects unauthorized users to the listings page
- Wrapped the landlord layout content with a `RoleGuard` component that checks for the "canCreateListings" permission
- Added necessary imports for useRouter, useEffect, and the RoleGuard component

### How to test?

1. Log in as a user with the "canCreateListings" permission and verify you can access landlord pages
2. Log in as a user without the "canCreateListings" permission and verify you are redirected to the listings page
3. Ensure the redirect happens automatically without showing any landlord UI elements

### Why make this change?

To improve security by ensuring only users with appropriate permissions can access the landlord section of the application. This prevents unauthorized users from viewing or interacting with landlord-specific features and redirects them to a more appropriate page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automatic redirection in the landlord area that sends unauthorized users to the listings page.
  - Improved user access control by integrating role-based permission checks for a smoother and more secure experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->