### PR TITLE
Add phone and occupation fields to account profile

### DIFF
--- a/app/(dashboard)/account/page.tsx
+++ b/app/(dashboard)/account/page.tsx
@@ -28,6 +28,14 @@ export default async function AccountPage() {
 
 	const userData = await db.query.user.findFirst({
 		where: eq(schema.user.id, session.user.id),
+		with: {
+			renterPreferences: {
+				columns: {
+					phone: true,
+					occupation: true,
+				},
+			},
+		},
 	});
 
 	if (!userData) {

--- a/components/accounts/account-profile.tsx
+++ b/components/accounts/account-profile.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -9,14 +10,29 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { SelectUser } from "@/schema/user";
-import { Badge } from "@/components/ui/badge";
+import type { UserRole } from "@/types/user";
 
-interface AccountProfileProps {
-	user: SelectUser;
+interface RenterPreference {
+	phone: string | null;
+	occupation: string | null;
 }
 
-export function AccountProfile({ user }: AccountProfileProps) {
+interface UserData {
+	image: string | null;
+	id: string;
+	role: UserRole | null;
+	email: string;
+	name: string;
+	emailVerified: boolean;
+	onboardingCompleted: boolean | null;
+	createdAt: Date;
+	updatedAt: Date;
+	renterPreferences: RenterPreference | null;
+}
+
+export function AccountProfile({ user }: { user: UserData | undefined }) {
+	const renterPreference = user?.renterPreferences;
+
 	return (
 		<Card>
 			<CardHeader>
@@ -28,13 +44,13 @@ export function AccountProfile({ user }: AccountProfileProps) {
 			<CardContent className="space-y-6">
 				<div className="flex items-center gap-4">
 					<Avatar className="h-20 w-20">
-						<AvatarImage src={user.image || ""} alt={user.name} />
-						<AvatarFallback>{user.name.split(" ")[0][0]}</AvatarFallback>
+						<AvatarImage src={user?.image || ""} alt={user?.name} />
+						<AvatarFallback>{user?.name.split(" ")[0][0]}</AvatarFallback>
 					</Avatar>
 					<div>
-						<h3 className="text-lg font-medium">{user.name}</h3>
-						<p className="text-sm text-muted-foreground">{user.email}</p>
-						<Badge variant="outline">{user.role}</Badge>
+						<h3 className="text-lg font-medium">{user?.name}</h3>
+						<p className="text-sm text-muted-foreground">{user?.email}</p>
+						<Badge variant="outline">{user?.role}</Badge>
 					</div>
 				</div>
 
@@ -42,7 +58,7 @@ export function AccountProfile({ user }: AccountProfileProps) {
 					<div className="space-y-2">
 						<Label>What should we call you?</Label>
 						<Input
-							defaultValue={user.name}
+							defaultValue={user?.name}
 							placeholder="Enter your preferred name"
 							type="text"
 						/>
@@ -50,16 +66,13 @@ export function AccountProfile({ user }: AccountProfileProps) {
 
 					<div className="space-y-2">
 						<Label>What is your email?</Label>
-						<Input
-							defaultValue={user.email}
-							placeholder="Enter your email"
-						/>
+						<Input defaultValue={user?.email} placeholder="Enter your email" />
 						<span className="text-sm text-muted-foreground">
 							<Badge variant="outline">
-								{user.emailVerified ? "Verified" : "Unverified"}
+								{user?.emailVerified ? "Verified" : "Unverified"}
 							</Badge>
 						</span>
-						{user.emailVerified && (
+						{user?.emailVerified && (
 							<p className="text-sm text-muted-foreground">
 								You can change your email address at any time.
 							</p>
@@ -71,32 +84,23 @@ export function AccountProfile({ user }: AccountProfileProps) {
 						<Badge variant="outline">{user?.role}</Badge>
 					</div>
 
-					 <div className="space-y-2">
-						<Label>What do you do?</Label>
+					<div className="space-y-2">
+						<Label>Phone Number</Label>
 						<Input
-							// defaultValue={user.occupation} 
-							placeholder="e.g. Software Developer"
-						/>
-					</div>
-
-					{/*
-					<div className="space-y-2">
-						<Label>What traits should we know about?</Label>
-						<Textarea
-							placeholder="Enter traits separated by commas (e.g. Chatty, Witty, Opinionated)"
-							className="min-h-[100px]"
-							defaultValue={user.traits?.join(", ")}
+							type="tel"
+							placeholder="Enter your phone number"
+							defaultValue={renterPreference?.phone as string}
 						/>
 					</div>
 
 					<div className="space-y-2">
-						<Label>Anything else we should know about you?</Label>
-						<Textarea
-							placeholder="Interests, values, or preferences to keep in mind"
-							className="min-h-[100px]"
-							defaultValue={user.bio}
+						<Label>Occupation</Label>
+						<Input
+							type="text"
+							placeholder="Enter your occupation"
+							defaultValue={renterPreference?.occupation as string}
 						/>
-					</div> */}
+					</div>
 				</div>
 
 				<div className="flex justify-end">

--- a/schema/renterPreferences.ts
+++ b/schema/renterPreferences.ts
@@ -43,3 +43,4 @@ export type SelectRenterPreferences = typeof renterPreferences.$inferSelect;
 
 /** Type for inserting renter preferences */
 export type InsertRenterPreferences = typeof renterPreferences.$inferInsert;
+

--- a/schema/user.ts
+++ b/schema/user.ts
@@ -1,23 +1,22 @@
-import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
-import { account } from "./account";
-import { session } from "./session";
-import { userRole } from "./userRole";
-import { property } from "./property";
-import { favorite } from "./favorite";
-import { searchHistory } from "./searchHistory";
-import { savedSearches } from "./savedSearches";
-import { leaseAgreements } from "./leaseAgreements";
-import { tenantFeedback } from "./tenantFeedback";
-import { rentPayments } from "./rentPayments";
-import { messages } from "./messages";
-import { notificationPreferences } from "./notificationPreferences";
-import { usageAnalytics } from "./usageAnalytics";
-import { securityLogs } from "./securityLogs";
-import { teamMember } from "./teamMember";
-import { propertyManagerFirm } from "./propertyManagerFirm";
-import { renterPreferences } from "./renterPreferences";
 import type { UserRole } from "@/types/user";
+import { relations } from "drizzle-orm";
+import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { account } from "./account";
+import { favorite } from "./favorite";
+import { leaseAgreements } from "./leaseAgreements";
+import { notificationPreferences } from "./notificationPreferences";
+import { property } from "./property";
+import { propertyManagerFirm } from "./propertyManagerFirm";
+import { rentPayments } from "./rentPayments";
+import { renterPreferences } from "./renterPreferences";
+import { savedSearches } from "./savedSearches";
+import { searchHistory } from "./searchHistory";
+import { securityLogs } from "./securityLogs";
+import { session } from "./session";
+import { teamMember } from "./teamMember";
+import { tenantFeedback } from "./tenantFeedback";
+import { usageAnalytics } from "./usageAnalytics";
+import { userRole } from "./userRole";
 
 /** User table for storing user information */
 export const user = pgTable("user", {
@@ -33,7 +32,7 @@ export const user = pgTable("user", {
 });
 
 /** Relations for the user table */
-export const userRelations = relations(user, ({ many }) => ({
+export const userRelations = relations(user, ({ many, one }) => ({
 	accounts: many(account),
 	sessions: many(session),
 	roles: many(userRole),
@@ -52,7 +51,7 @@ export const userRelations = relations(user, ({ many }) => ({
 	securityLogs: many(securityLogs),
 	teamMembers: many(teamMember),
 	propertyManagerFirms: many(propertyManagerFirm),
-	renterPreferences: many(renterPreferences),
+	renterPreferences: one(renterPreferences),
 }));
 
 /** Type for selecting users */


### PR DESCRIPTION
### TL;DR

Added renter preferences to the account profile page, including phone number and occupation fields.

### What changed?

- Updated the account page to fetch renter preferences (phone and occupation) along with user data
- Enhanced the `AccountProfile` component to display and allow editing of renter preferences
- Modified the user schema to establish a one-to-one relationship with renter preferences instead of one-to-many
- Added new input fields for phone number and occupation in the account profile form

### How to test?

1. Navigate to the account page
2. Verify that any existing phone number and occupation data is displayed in the form
3. Try updating these fields and check if they save correctly
4. Confirm that the relationship between user and renter preferences works as expected

### Why make this change?

This change improves the user profile by including essential renter information that was previously missing. Having phone number and occupation details readily available in the account section provides a more complete user profile and enhances the user experience for renters using the platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User account profiles now display and allow editing of phone number and occupation fields from renter preferences.

- **Refactor**
  - Improved type safety and code clarity in the account profile component.
  - Cleaned up the user profile form by removing unused fields and updating the UI for better handling of optional data.

- **Style**
  - Minor adjustments to input types and display for new renter preference fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->